### PR TITLE
Load Vesicles from Tomogram on demand

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,5 +19,12 @@ This tomography plugin can be enabled by cloning this repository and execute the
     git clone https://github.com/scipion-em/scipion-em-tomo3D.git
     scipion installp -p ~/scipion-em-tomo3D --devel
 
+The plugin needs PyQt5 to be installed in the device. The following commands can be used to install PyQt5 in different distributions:
 
+.. code-block::
+    
+    Ubuntu:
+    sudo apt-get install python3-pyqt5
 
+    CentOS:
+    yum install qt5-qtbase-devel

--- a/tomo3D/viewers/viewers_data.py
+++ b/tomo3D/viewers/viewers_data.py
@@ -31,7 +31,6 @@ import pwem.viewers.views as vi
 from .views_tkinter_tree import Tomo3DTreeProvider
 from .views_tkinter_tree import Tomo3DDialog
 
-from tomo.utils import extractVesicles
 import tomo.objects
 
 
@@ -64,10 +63,9 @@ class Tomo3DDataViewer(pwviewer.Viewer):
             volIds = outputCoords.aggregate(["MAX"], "_volId", ["_volId"])
             volIds = [d['_volId'] for d in volIds]
 
-            tomoList = [tomos[objId] for objId in volIds]
+            tomoList = [tomos[objId].clone() for objId in volIds]
             tomoProvider = Tomo3DTreeProvider(tomoList)
 
-            vesicles_dict = extractVesicles(outputCoords)
-            Tomo3DDialog(self._tkRoot, vesicles_dict, provider=tomoProvider)
+            Tomo3DDialog(self._tkRoot, outputCoords, provider=tomoProvider)
 
         return views

--- a/tomo3D/viewers/views_tkinter_tree.py
+++ b/tomo3D/viewers/views_tkinter_tree.py
@@ -33,6 +33,8 @@ from pyworkflow.gui.tree import TreeProvider
 from .viewer_triangulations import TriangulationPlot
 from ..utils import delaunayTriangulation
 
+from tomo.utils import extractVesicles, initDictVesicles
+
 class Tomo3DTreeProvider(TreeProvider):
     """ Populate Tree from SetOfTomograms. """
 
@@ -74,8 +76,9 @@ class Tomo3DDialog(ToolbarListDialog):
     a pyvista viewer subprocess from a list of Tomograms.
     """
 
-    def __init__(self, parent, vesicles_dict, **kwargs):
-        self.vesicles_dict = vesicles_dict
+    def __init__(self, parent, coordinates, **kwargs):
+        self.dictVesicles, _ = initDictVesicles(coordinates)
+        self.coordinates = coordinates
         self.provider = kwargs.get("provider", None)
         ToolbarListDialog.__init__(self, parent,
                                    "Tomogram List",
@@ -85,7 +88,9 @@ class Tomo3DDialog(ToolbarListDialog):
 
     def doubleClickOnTomogram(self, e=None):
         self.tomo = e
-        self.proc = Process(target=createViewer, args=(self.tomo, self.vesicles_dict))
+        tomoName = pwutils.removeBaseExt(self.tomo.getFileName())
+        self.dictVesicles = extractVesicles(self.coordinates, self.dictVesicles, tomoName)
+        self.proc = Process(target=createViewer, args=(self.tomo, self.dictVesicles))
         self.proc.start()
 
 def createViewer(tomo, vesicles_dict):


### PR DESCRIPTION
Modify the vesicles viewer of Tomo3D to work with the changes included in [#84](https://github.com/scipion-em/scipion-em-tomo/pull/84/files). This should improve the loading times of the tomograms list interface.