### PR TITLE
New interactive viewer for Tomograms

### DIFF
--- a/tomo3D/__init__.py
+++ b/tomo3D/__init__.py
@@ -27,7 +27,7 @@
 
 import pwem
 
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 _logo = "icon.png"
 _references = ['you2019']
 

--- a/tomo3D/viewers/viewer_mrc.py
+++ b/tomo3D/viewers/viewer_mrc.py
@@ -112,7 +112,7 @@ class MrcPlot(object):
             self.plt.add_text('Tomogram', position=(pos, 65.), font_size=12)
             pos += 170.
             self.buttonSliceTomo = self.plt.add_checkbox_button_widget(callback=self.toogleSlice, position=(pos, 10.))
-            self.plt.add_text('Slice Mode', position=(pos, 65.), font_size=12)
+            self.plt.add_text('Slice mode', position=(pos, 65.), font_size=12)
 
         if isinstance(self.mask, np.ndarray):
             pos += 170. if pos != 0 else 45.
@@ -141,7 +141,7 @@ class MrcPlot(object):
                                              font_size=12, opacity=0)
 
             # Picking Controls
-            self.plt.main_menu.addAction('Point Removal', enableRemoveSelection)
+            self.plt.main_menu.addAction('Point removal', enableRemoveSelection)
 
         if isinstance(self.normals, np.ndarray):
             pos += 170. if pos != 0 else 45.

--- a/tomo3D/viewers/viewer_mrc.py
+++ b/tomo3D/viewers/viewer_mrc.py
@@ -60,7 +60,14 @@ class MrcPlot(object):
     '''
 
     def __init__(self, tomo_mrc=None, mask_mrc=None, points=None, normals=None,
-                 binning=1, sigma=1., triangulation=False):
+                 binning=None, sigma=1., triangulation=False):
+        if binning is None:
+            if tomo_mrc is not None:
+                binning = self.getBinning(tomo_mrc)
+            elif mask_mrc is not None:
+                binning = self.getBinning(mask_mrc)
+            else:
+                binning = 0
         self.tomo = self.readMRC(tomo_mrc, order=5, binning=binning) if tomo_mrc is not None else None
         self.mask = self.readMRC(mask_mrc, binning=binning) if mask_mrc is not None else None
         self.points = np.loadtxt(points, delimiter=' ') if points is not None else None
@@ -135,6 +142,9 @@ class MrcPlot(object):
             self.plt.add_text('Directions', position=(pos, 65.), font_size=12)
             self.buttonNormals = self.plt.add_checkbox_button_widget(callback=self.plotNormals, position=(pos, 10.))
 
+    def getBinning(self, file):
+        dim = ImageHandler().read(file + ':mrc').getDimensions()
+        return int(np.floor(max(dim) / 400))
 
     def readMRC(self, file, binning=1, order=0, swapaxes=True):
         image = ImageHandler().read(file + ':mrc')

--- a/tomo3D/viewers/viewers_data.py
+++ b/tomo3D/viewers/viewers_data.py
@@ -31,7 +31,7 @@ from pyworkflow.object import String
 from pwem.protocols import EMProtocol
 import pwem.viewers.views as vi
 from .views_tkinter_tree import Tomo3DTreeProvider
-from .views_tkinter_tree import Tomo3DDialog
+from .views_tkinter_tree import Tomo3DDialog, ViewerMRCDialog
 
 import tomo.objects
 from ..protocols import XmippProtFilterbyNormal
@@ -69,13 +69,13 @@ class Tomo3DDataViewer(pwviewer.Viewer):
         volIds = outputCoords.aggregate(["MAX"], "_volId", ["_volId"])
         volIds = [d['_volId'] for d in volIds]
 
-        # tomoList = [tomos[objId].clone() for objId in volIds]
-        tomoList = [String(tomos[objId].getFileName()) for objId in volIds]
+        tomoList = [tomos[objId].clone() for objId in volIds]
+        # tomoList = [String(tomos[objId].getFileName()) for objId in volIds]
         tomoProvider = Tomo3DTreeProvider(tomoList)
 
         if issubclass(cls, tomo.objects.SetOfCoordinates3D):
-            Tomo3DDialog(self._tkRoot, outputCoords, None, provider=tomoProvider)
+            ViewerMRCDialog(self._tkRoot, outputCoords, provider=tomoProvider)
         elif issubclass(cls, EMProtocol):
-            Tomo3DDialog(self._tkRoot, outputCoords, obj.outputset, provider=tomoProvider)
+            ViewerMRCDialog(self._tkRoot, outputCoords, provider=tomoProvider)
 
         return views

--- a/tomo3D/viewers/viewers_data.py
+++ b/tomo3D/viewers/viewers_data.py
@@ -23,10 +23,14 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
+import os.path
 
-
+import numpy as np
 import pyworkflow.viewer as pwviewer
 from pyworkflow.object import String
+from pyworkflow.gui.dialog import askYesNo
+from pyworkflow.utils.properties import Message
+import pyworkflow.utils as pwutils
 
 from pwem.protocols import EMProtocol
 import pwem.viewers.views as vi
@@ -72,10 +76,37 @@ class Tomo3DDataViewer(pwviewer.Viewer):
         tomoList = [tomos[objId].clone() for objId in volIds]
         # tomoList = [String(tomos[objId].getFileName()) for objId in volIds]
         tomoProvider = Tomo3DTreeProvider(tomoList)
+        ViewerMRCDialog(self._tkRoot, outputCoords, provider=tomoProvider)
 
-        if issubclass(cls, tomo.objects.SetOfCoordinates3D):
-            ViewerMRCDialog(self._tkRoot, outputCoords, provider=tomoProvider)
-        elif issubclass(cls, EMProtocol):
-            ViewerMRCDialog(self._tkRoot, outputCoords, provider=tomoProvider)
+        import tkinter as tk
+        frame = tk.Frame()
+        if askYesNo(Message.TITLE_SAVE_OUTPUT, Message.LABEL_SAVE_OUTPUT, frame):
+            protocol = self.protocol
+            suffix = protocol._getOutputSuffix(tomo.objects.SetOfCoordinates3D)
+            updated_set = protocol._createSetOfCoordinates3D(tomos, suffix)
+            updated_set.setName("Selected Coordinates")
+            updated_set.setPrecedents(tomos)
+            updated_set.setSamplingRate(tomos.getSamplingRate())
+            updated_set.setBoxSize(outputCoords.getBoxSize())
+            for item in tomoList:
+                basename = pwutils.removeBaseExt(item.getFileName())
+                indices_file = basename + '_indices.txt'
+                if os.path.isfile(indices_file):
+                    indices = np.loadtxt(indices_file, delimiter=' ')
+                    for index in indices:
+                        updated_set.append(outputCoords[index].clone())
+                    pwutils.cleanPath(indices_file)
+            name = protocol.OUTPUT_PREFIX + suffix
+            args = {}
+            args[name] = updated_set
+            protocol._defineOutputs(**args)
+            protocol._defineSourceRelation(tomos, updated_set)
+            protocol._updateOutputSet(name, updated_set, state=updated_set.STREAM_CLOSED)
+        else:
+            for item in tomoList:
+                basename = pwutils.removeBaseExt(item.getFileName())
+                indices_file = basename + '_indices.txt'
+                if os.path.isfile(indices_file):
+                    pwutils.cleanPath(indices_file)
 
         return views

--- a/tomo3D/viewers/views_tkinter_tree.py
+++ b/tomo3D/viewers/views_tkinter_tree.py
@@ -147,7 +147,8 @@ class ViewerMRCDialog(ToolbarListDialog):
             direction = normalFromMatrix(coord.getMatrix())
             position = [coord.getX(const.BOTTOM_LEFT_CORNER),
                         coord.getY(const.BOTTOM_LEFT_CORNER),
-                        coord.getZ(const.BOTTOM_LEFT_CORNER)]
+                        coord.getZ(const.BOTTOM_LEFT_CORNER),
+                        coord.getObjId()]
             coord_list.append(position)
             direction_list.append(direction)
         np.savetxt('positions.txt', np.asarray(coord_list))

--- a/tomo3D/viewers/views_tkinter_tree.py
+++ b/tomo3D/viewers/views_tkinter_tree.py
@@ -23,12 +23,13 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-
+import numpy as np
 from pyworkflow import utils as pwutils
 from pyworkflow.gui.dialog import ToolbarListDialog
 from pyworkflow.gui.tree import TreeProvider
 
 from .viewer_triangulations import TriangulationPlot, guiThread
+from .viewer_mrc import MrcPlot
 from ..utils import delaunayTriangulation
 
 from tomo.utils import extractVesicles, initDictVesicles, normalFromMatrix
@@ -45,8 +46,8 @@ class Tomo3DTreeProvider(TreeProvider):
         return [('Tomogram', 300)]
 
     def getObjectInfo(self, tomo):
-        # tomogramName = pwutils.removeBaseExt(tomo.getFileName())
-        tomogramName = pwutils.removeBaseExt(tomo.get())
+        tomogramName = pwutils.removeBaseExt(tomo.getFileName())
+        # tomogramName = pwutils.removeBaseExt(tomo.get())
 
         return {'key': tomogramName, 'parent': None,
                 'text': tomogramName,
@@ -122,3 +123,34 @@ class Tomo3DDialog(ToolbarListDialog):
 
         classArgs = {'meshes': shells, 'clouds': vesicles, 'extNormals_List': normals, 'extNormals_coords': extcoords}
         guiThread(TriangulationPlot, 'initializePlot', **classArgs)
+
+class ViewerMRCDialog(ToolbarListDialog):
+    """
+    This class extend from ListDialog to allow calling
+    a pyvista viewer subprocess from a list of Tomograms.
+    """
+
+    def __init__(self, parent, coords, **kwargs):
+        self.coords = coords
+        self.provider = kwargs.get("provider", None)
+        ToolbarListDialog.__init__(self, parent,
+                                   "Tomogram List",
+                                   allowsEmptySelection=False,
+                                   itemDoubleClick=self.doubleClickOnTomogram,
+                                   **kwargs)
+
+    def doubleClickOnTomogram(self, tomo=None):
+        tomo_path = tomo.getFileName()
+        coord_list = []
+        direction_list = []
+        for coord in self.coords.iterCoordinates(volume=tomo):
+            direction = normalFromMatrix(coord.getMatrix())
+            position = [coord.getX(const.BOTTOM_LEFT_CORNER),
+                        coord.getY(const.BOTTOM_LEFT_CORNER),
+                        coord.getZ(const.BOTTOM_LEFT_CORNER)]
+            coord_list.append(position)
+            direction_list.append(direction)
+        np.savetxt('positions.txt', np.asarray(coord_list))
+        np.savetxt('directions.txt', np.asarray(direction_list))
+        viewer_args = {'tomo_mrc': tomo_path, 'points': 'positions.txt', 'normals': 'directions.txt'}
+        guiThread(MrcPlot, 'initializePlot', **viewer_args)


### PR DESCRIPTION
The class `MrcPlot` has been extended to add several functionalities:

- 3D Tomogram representation: `Tomograms` can be now visualize in 3D thanks to a ray-tracing method based on the contrast present in the volume. To complement this visualization, there exists the possibility to show the `Tomograms` in slice mode.
- Coordinates Support: Added the possibility of giving a text file with coordinates to the viewer to render them in a 3D scatter plot
- Normals Support:  Added the possibility of giving a text file with directions/normals to the viewer to render them in their corresponding positions in the 3D scatter plot
- Interactive Coordinate removal: If any coordinates are provided to the viewer, a button will be created automatically in the toolbar to activate an interactive selection and deletion of coordinates. These coordinates are saved when the viewer is closed to use them later. 